### PR TITLE
Add a positional search for IN

### DIFF
--- a/carting/context_processors.py
+++ b/carting/context_processors.py
@@ -5,7 +5,8 @@ def menu(request):
     return {
         "menu": {
             "Carting": {
-                "Démo": reverse("carting:index"),
+                "Recherche texte": reverse("carting:search_by_text"),
+                "Recherche position": reverse("carting:search_by_position"),
             },
         }
     }

--- a/carting/models.py
+++ b/carting/models.py
@@ -95,6 +95,11 @@ class SectionTypology(Enum):
     def choices(cls) -> list[tuple[str, str]]:
         return [(member.name, member.label) for member in cls]
 
+    @classmethod
+    @property
+    def paragraph_likes(cls):
+        return {member for member in cls if member.ingester == ParagraphIngester}
+
 
 def find_ingestable_child_elements(
     element: ElementTree.Element,

--- a/carting/urls.py
+++ b/carting/urls.py
@@ -1,9 +1,17 @@
 from django.urls import path
+from django.views.generic import RedirectView
 
 from . import views
 
 urlpatterns = [
-    path("", views.index, name="index"),
+    path("", RedirectView.as_view(pattern_name="carting:search_by_position")),
+    path("text", views.search_by_text, name="search_by_text"),
+    path("position", views.search_by_position, name="search_by_position"),
+    path(
+        "position/<uuid:root_expanded>/<uuid:expanded>",
+        views.search_by_position_details,
+        name="search_by_position_details",
+    ),
     path(
         "proxy/wms",
         views.wms_proxy,

--- a/carting/views.py
+++ b/carting/views.py
@@ -1,4 +1,8 @@
+import json
+from uuid import UUID
+
 import requests
+from django.contrib.gis import geos
 from django.core.serializers import serialize
 from django.http import Http404, HttpRequest, HttpResponse
 from django.shortcuts import redirect, render
@@ -7,33 +11,97 @@ from django.views.decorators.http import require_GET
 
 from carting.models import OuvrageSection, SectionTypology
 
+SAINT_MALO_BBOX = "-3.15, 47.32, -1.65, 49.14"
+
+
+@require_GET
+def search_by_position(request: HttpRequest) -> HttpResponse:
+    zoom_level = float(request.GET.get("zoom", 1))
+
+    qs_bbox = request.GET.get("bbox", SAINT_MALO_BBOX)
+    qs_bbox = [float(coordinate) for coordinate in qs_bbox.split(",")]
+    bbox = geos.Polygon.from_bbox(qs_bbox)
+
+    allowed_typologies = SectionTypology.paragraph_likes
+    if zoom_level < 7:
+        allowed_typologies = [SectionTypology.CHAPTER]
+
+    sections = (
+        OuvrageSection.objects.filter(geometry__bboverlaps=bbox)
+        # FIXME : A geometry is not excluded by filter below 75f7dbbd-c0b4-456f-bc10-19f72f89608b
+        .exclude(geometry__contains_properly=bbox).filter(
+            typology__in=[x.name for x in allowed_typologies]
+        )
+    )
+
+    geojson = serialize("geojson", (s for s in sections if s.geometry))
+
+    return render(
+        request,
+        "carting/search_by_position.html",
+        {
+            "scroll_snap": True,
+            "geojson": geojson,
+            "bbox": json.dumps(qs_bbox),
+            "zoom_level": zoom_level,
+            "sections": sections,
+        },
+    )
+
+
+@require_GET
+def search_by_position_details(
+    request: HttpRequest, root_expanded: UUID, expanded: UUID
+) -> HttpResponse:
+    zoom_level = float(request.GET.get("zoom", 1))
+
+    qs_bbox = request.GET.get("bbox", SAINT_MALO_BBOX)
+    qs_bbox = [float(coordinate) for coordinate in qs_bbox.split(",")]
+
+    expanded_section = OuvrageSection.objects.prefetch_related("children").get(
+        pk=expanded
+    )
+
+    to_serialize = [expanded_section, *expanded_section.children.all()]
+    geojson = serialize("geojson", (s for s in to_serialize if s.geometry))
+
+    return render(
+        request,
+        "carting/search_by_position.html",
+        {
+            "scroll_snap": True,
+            "geojson": geojson,
+            "bbox": json.dumps(qs_bbox),
+            "zoom_level": zoom_level,
+            "root_expanded": root_expanded,
+            "expanded": expanded,
+            "expanded_section": expanded_section,
+        },
+    )
+
 
 # FIXME : Les sections commençant par '0.' ne devraient pas être affichées (pas de géométrie attachée); les illustrations en '0.' sont mal ordonnées
 @require_GET
-def index(request: HttpRequest) -> HttpResponse:
+def search_by_text(request: HttpRequest) -> HttpResponse:
     search = request.GET.get("search", "")
 
     if not search:
-        return redirect(reverse("carting:index") + "?search=4.1.")
+        return redirect(reverse("carting:search_by_text") + "?search=4.1.")
 
     if not search.endswith("."):
-        return redirect(reverse("carting:index") + f"?search={search}.")
+        return redirect(reverse("carting:search_by_text") + f"?search={search}.")
 
     ouvrage, _, numero = search.rpartition("/")
     if not numero:
         return render(
             request,
-            "carting/index.html",
+            "carting/search_by_text.html",
         )
-
-    sections = OuvrageSection.objects.exclude(
-        typology__in=[
-            SectionTypology.ALINEA.name,
-            SectionTypology.ILLUSTRATION.name,
-            SectionTypology.REFERENCE.name,
-            SectionTypology.TABLE.name,
-            SectionTypology.TOPONYME.name,
-        ]
+    allowed_typologies = SectionTypology.paragraph_likes.union(
+        {SectionTypology.OUVRAGE}
+    )
+    sections = OuvrageSection.objects.filter(
+        typology__in=[x.name for x in allowed_typologies]
     ).with_tree_fields()
     if ouvrage:
         sections = sections.filter(ouvrage_name=ouvrage)
@@ -53,7 +121,7 @@ def index(request: HttpRequest) -> HttpResponse:
     geojson = serialize("geojson", (s for s in sections if s.geometry))
     return render(
         request,
-        "carting/index.html",
+        "carting/search_by_text.html",
         {
             "sections": sections,
             "geojson": geojson,

--- a/carting/xslt/ouvrage_section_html.xslt
+++ b/carting/xslt/ouvrage_section_html.xslt
@@ -37,6 +37,7 @@
             id="{@bpn_id}"
             href="#{@bpn_id}"
             class="sn-scroll-mt-[20vh]"
+            data-turbo="false"
         >
             <xsl:apply-templates />
         </a>

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
             "dependencies": {
                 "@gouvfr/dsfr": "^1.7.2",
                 "@hotwired/stimulus": "^3.2.1",
+                "@hotwired/turbo": "^7.3.0",
                 "ol": "^7.3.0",
                 "parcel": "^2.9.2",
                 "prettier": "^2.8.8",
@@ -124,6 +125,14 @@
             "version": "3.2.1",
             "resolved": "https://registry.npmjs.org/@hotwired/stimulus/-/stimulus-3.2.1.tgz",
             "integrity": "sha512-HGlzDcf9vv/EQrMJ5ZG6VWNs8Z/xMN+1o2OhV1gKiSG6CqZt5MCBB1gRg5ILiN3U0jEAxuDTNPRfBcnZBDmupQ=="
+        },
+        "node_modules/@hotwired/turbo": {
+            "version": "7.3.0",
+            "resolved": "https://registry.npmjs.org/@hotwired/turbo/-/turbo-7.3.0.tgz",
+            "integrity": "sha512-Dcu+NaSvHLT7EjrDrkEmH4qET2ZJZ5IcCWmNXxNQTBwlnE5tBZfN6WxZ842n5cHV52DH/AKNirbPBtcEXDLW4g==",
+            "engines": {
+                "node": ">= 14"
+            }
         },
         "node_modules/@jridgewell/gen-mapping": {
             "version": "0.3.2",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "dependencies": {
         "@gouvfr/dsfr": "^1.7.2",
         "@hotwired/stimulus": "^3.2.1",
+        "@hotwired/turbo": "^7.3.0",
         "ol": "^7.3.0",
         "parcel": "^2.9.2",
         "prettier": "^2.8.8",

--- a/static/to_compile/entrypoints/carting.ts
+++ b/static/to_compile/entrypoints/carting.ts
@@ -1,4 +1,5 @@
 import { Application } from "@hotwired/stimulus"
+import * as Turbo from "@hotwired/turbo"
 
 import MapController from "../src/map_controller"
 import PopinController from "../src/popin_controller"
@@ -6,3 +7,5 @@ import PopinController from "../src/popin_controller"
 window.stimulus = Application.start()
 stimulus.register("map", MapController)
 stimulus.register("popin", PopinController)
+
+Turbo.session.drive = false

--- a/static/to_compile/src/map_controller.ts
+++ b/static/to_compile/src/map_controller.ts
@@ -1,27 +1,34 @@
 import { Controller } from "@hotwired/stimulus"
-import type { default as PopinController } from "./popin_controller"
+import type { FrameElement } from "@hotwired/turbo"
 
-import { Coordinate } from "ol/coordinate"
+import type { Coordinate } from "ol/coordinate"
+import type { Extent } from "ol/extent"
+
+import type { default as PopinController } from "./popin_controller"
 import { SectionMap } from "./section_map"
 
 export default class extends Controller<HTMLElement> {
-    #map
+    #map: SectionMap
 
-    static targets = ["map", "geojson", "featurePopin"]
+    static targets = ["map", "geojson", "featurePopin", "turboframe"]
     readonly mapTarget: HTMLElement
     readonly geojsonTarget: HTMLScriptElement
     readonly featurePopinTarget: HTMLElement
+    readonly turboframeTarget: FrameElement
 
     static values = {
         initialCenter: { type: Array, default: [-2.0, 48.65] },
         maxZoom: { type: Number, default: 13 },
         wmsUrl: String,
+        bbox: Array,
     }
     readonly initialCenterValue: Coordinate
     readonly maxZoomValue: number
     readonly wmsUrlValue: string
+    readonly hasBboxValue: boolean
+    readonly bboxValue: Extent
 
-    connect() {
+    initialize() {
         this.#map = new SectionMap({
             target: this.mapTarget,
             initialCenter: this.initialCenterValue,
@@ -30,9 +37,29 @@ export default class extends Controller<HTMLElement> {
             wmsUrl: this.wmsUrlValue,
             fullscreenElement: this.element,
         })
-
         this.#map.fitViewToAllSections()
+
+        if (this.hasBboxValue) {
+            this.#map.fitMapToExtent(this.bboxValue, { withAnimation: false })
+        }
+
         this.selectSectionInMapFromHash()
+    }
+
+    geojsonTargetConnected() {
+        this.#map.updateGeoJson(this.geojsonTarget.textContent)
+    }
+
+    updateBboxInUrl(event) {
+        const { bbox, zoom } = event.detail
+
+        const url = new URL(location.href)
+        url.searchParams.set("bbox", bbox)
+        url.searchParams.set("zoom", zoom)
+        this.turboframeTarget.src = url.toString()
+        // FIXME : turbo does not update the url when the bbox changes
+        // It requires one click inside the frame, and after it works properly
+        // Similar issue https://github.com/hotwired/turbo/issues/489
     }
 
     selectSectionInText(event) {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -35,6 +35,10 @@ module.exports = {
             "15w": "7.5rem",
         },
         extend: {
+            aria: {
+                // Remove when https://github.com/tailwindlabs/tailwindcss/pull/10966 in a release
+                busy: "busy=true",
+            },
             minWidth: ({ theme }) => ({ ...theme("spacing") }),
         },
     },

--- a/templates/carting/cards/alinea.html
+++ b/templates/carting/cards/alinea.html
@@ -1,0 +1,19 @@
+<div
+    id="{{section.pk}}"
+    class="sn-flex sn-gap-1w sn-mb-1w sn-max-w-readable target:sn-bg-info-975-active sn-scroll-mt-[20vh]"
+>
+<span class="sn-min-w-5w">
+    {% if section.geometry %}
+        <a
+            href="#{{ section.pk }}"
+            data-turbo="false"
+            class="fr-btn fr-btn--tertiary-no-outline fr-icon-map-pin-2-line"
+        >
+            Montrer sur la carte
+        </a>
+    {% endif %}
+</span>
+<div>
+    {{ section.content_html }}
+</div>
+</div>

--- a/templates/carting/cards/title.html
+++ b/templates/carting/cards/title.html
@@ -1,0 +1,58 @@
+<div
+    class="
+        fr-card fr-card--sm
+        !sn-h-auto target:sn-bg-info-975-active
+        {% if section.pk|safe == request.GET.expanded %}sn-bg-info-975-active{% endif %}
+    "
+    id="{{section.pk}}"
+>
+    <div class="fr-card__body">
+        <div class="fr-card__content">
+            <div class="fr-card__title">
+                {{ section.content_html }}
+            </div>
+        </div>
+        <div class="fr-card__footer">
+            <ul class="fr-btns-group fr-btns-group--inline fr-btns-group--right fr-btns-group--icon-left">
+                <li>
+                    {% if user.is_staff %}
+                        <a
+                            href="{% url "admin:carting_ouvragesection_change" section.pk %}"
+                            data-turbo="false"
+                            class="fr-btn fr-btn--tertiary-no-outline fr-icon-pencil-line"
+                            >
+                            Éditer
+                        </a>
+                    {% endif %}
+
+                    {% if section.geometry %}
+                        <a
+                            href="#{{ section.pk }}"
+                            class="fr-btn fr-btn--tertiary-no-outline fr-icon-map-pin-2-line"
+                            data-turbo="false"
+                            data-action="
+                                mouseenter->map#highlightSectionInMap
+                                mouseleave->map#unhighlightSectionInMap
+                            "
+                        >
+                            Montrer
+                        </a>
+                    {% endif %}
+                    {% if section.pk|safe != request.GET.expanded %}
+                        <a
+                            {% if root_expanded %}
+                                href="{% url 'carting:search_by_position_details' root_expanded=root_expanded expanded=section.pk %}?{{request.GET.urlencode}}"
+                            {% else %}
+                                href="{% url 'carting:search_by_position_details' root_expanded=section.pk expanded=section.pk %}?{{request.GET.urlencode}}"
+                            {% endif %}
+                            class="fr-btn fr-btn--tertiary-no-outline fr-icon-arrow-right-line"
+                        >
+                            Détails
+                        </a>
+                    {% endif %}
+                </li>
+            </ul>
+        </div>
+
+    </div>
+</div>

--- a/templates/carting/partial/layer_popin.html
+++ b/templates/carting/partial/layer_popin.html
@@ -1,0 +1,20 @@
+<div
+    data-controller="popin"
+    data-map-target="featurePopin"
+    aria-hidden="true"
+    class="
+        sn-flex aria-hidden:sn-hidden sn-sticky sn-top-0 sn-h-screen sn-flex-col sn-z-10
+        fr-p-1w fr-background-default--grey
+    "
+    >
+    <button
+        data-action="popin#close"
+        class="fr-mb-1w fr-btn fr-btn--icon-right fr-btn--tertiary fr-icon-close-circle-fill"
+    >
+        Fermer
+    </button>
+    <div
+        data-popin-target="content"
+        class="sn-overflow-y-auto sn-overscroll-contain"
+    ></div>
+</div>

--- a/templates/carting/search_by_position.html
+++ b/templates/carting/search_by_position.html
@@ -1,0 +1,114 @@
+{% extends "layout/base.html" %}
+
+{% load static %}
+
+{% block page_title %}Carting - Recherche position{% endblock%}
+
+{% block extra_css %}
+<link rel="stylesheet" href="{% static "carting.css" %}">
+{% endblock %}
+
+{% block js %}
+<script type="module" src="{% static "carting.js" %}"></script>
+{% endblock %}
+
+{% block main %}
+<div
+    class="
+        fr-container--fluid
+        sn-snap-always sn-snap-start
+    "
+>
+    <div
+        data-controller="map"
+        data-map-wms-url-value="{% url 'carting:wms-proxy' %}"
+        data-map-bbox-value="{{ bbox }}"
+        data-action="
+            ol:select->map#selectSectionInText
+            ol:changed->map#updateBboxInUrl
+            wms:featureInfoFetched->map#showFeaturePopin
+            hashchange@window->map#selectSectionInMapFromHash
+            hashchange@window->map#closeFeaturePopin
+        "
+        class="
+            fr-grid-row fr-m-1w
+            sn-bg-white
+        "
+    >
+        <div class="fr-col-12 fr-col-md-7">
+            <div
+                id="map"
+                data-map-target="map"
+                class="
+                    sn-h-screen sn-w-full
+                    fr-p-1w
+                "
+            >
+            </div>
+        </div>
+        <div class="
+                sn-relative
+                fr-col-12 fr-col-md-5 fr-p-1w
+            "
+        >
+            {% include 'carting/partial/layer_popin.html' %}
+
+            <turbo-frame
+                id="sections"
+                data-map-target="turboframe"
+                data-turbo-action="advance"
+                class="
+                    sn-block sn-h-screen sn-overflow-auto sn-overscroll-contain sn-px-1v sn-pb-1v
+                    aria-busy:sn-opacity-50 sn-transition-opacity sn-ease-in aria-busy:sn-delay-150
+                "
+            >
+                <script type="application/geojson" data-map-target="geojson">
+                    {{ geojson|safe }}
+                </script>
+                {% if expanded %}
+                    <div class="sn-sticky sn-top-0 sn-bg-white sn-z-10">
+                        <a
+                            {% if expanded_section.pk == root_expanded %}
+                                href="{% url 'carting:search_by_position' %}?{{request.GET.urlencode}}"
+                            {% else %}
+                                href="{% url 'carting:search_by_position_details' root_expanded=root_expanded expanded=expanded_section.parent.pk %}?{{request.GET.urlencode}}"
+                            {% endif %}
+                            class="fr-mb-1w fr-btn fr-btn--icon-left fr-btn--secondary fr-icon-arrow-left-line"
+                        >
+                            Retour
+                        </a>
+                    </div>
+                    {% if expanded_section %}
+                        {% include 'carting/cards/title.html' with section=expanded_section %}
+                    {% endif %}
+                    {% for section in expanded_section.children.all %}
+                        {% if section.typology == "ALINEA" %}
+                            {% ifchanged section.typology %}
+                                <div class="sn-m-2w">
+                            {% endifchanged %}
+
+                            {% include 'carting/cards/alinea.html' %}
+
+                            {% if forloop.last %}
+                                </div>
+                            {% endif %}
+                        {% else %}
+                            {% ifchanged section.typology %}
+                                {% if not forloop.first %}
+                                    </div>
+                                {% endif %}
+                            {% endifchanged %}
+
+                            {% include 'carting/cards/title.html' %}
+                        {% endif %}
+                    {% endfor %}
+                {% else %}
+                    {% for section in sections %}
+                        {% include 'carting/cards/title.html' %}
+                    {% endfor %}
+                {% endif %}
+            </turbo-frame>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/templates/carting/search_by_text.html
+++ b/templates/carting/search_by_text.html
@@ -2,7 +2,7 @@
 
 {% load static %}
 
-{% block page_title %}Carting{% endblock%}
+{% block page_title %}Carting - Recherche texte{% endblock%}
 
 {% block extra_css %}
 <link rel="stylesheet" href="{% static "carting.css" %}">
@@ -47,26 +47,8 @@
                 fr-col-12 fr-col-md-5 fr-p-1w
             "
         >
-            <div
-                data-controller="popin"
-                data-map-target="featurePopin"
-                aria-hidden="true"
-                class="
-                    sn-flex aria-hidden:sn-hidden sn-sticky sn-top-0 sn-h-screen sn-flex-col sn-z-10
-                    fr-p-1w fr-background-default--grey
-                "
-            >
-                <button
-                    data-action="popin#close"
-                    class="fr-mb-1w fr-btn fr-btn--icon-right fr-btn--tertiary fr-icon-close-circle-fill"
-                >
-                    Fermer
-                </button>
-                <div
-                    data-popin-target="content"
-                    class="sn-overflow-y-auto sn-overscroll-contain"
-                ></div>
-            </div>
+            {% include 'carting/partial/layer_popin.html' %}
+
             <form>
                 <div class="fr-search-bar" role="search">
                     <input

--- a/templates/layout/base.html
+++ b/templates/layout/base.html
@@ -25,6 +25,9 @@
     </head>
 
     <body>
+    {% if scroll_snap %}
+        <div class="sn-max-h-screen sn-overflow-auto sn-snap-y sn-snap-mandatory">
+    {% endif %}
         {% block header %}
             {% include "layout/header.html" %}
         {% endblock %}
@@ -67,5 +70,8 @@
 
         <script type="module" src="{% static "sppnaut.js" %}"></script>
         {% block js %}{% endblock %}
+    {% if scroll_snap %}
+        </div>
+    {% endif %}
     </body>
 </html>

--- a/templates/layout/footer.html
+++ b/templates/layout/footer.html
@@ -1,6 +1,13 @@
 {% load static %}
 
-<footer class="fr-footer" role="contentinfo" id="footer">
+<footer
+    class="
+        fr-footer
+        sn-snap-always sn-snap-start
+    "
+    role="contentinfo"
+    id="footer"
+>
     <div class="fr-container">
         <div class="fr-footer__body">
             <div class="fr-footer__brand fr-enlarge-link">

--- a/templates/layout/header.html
+++ b/templates/layout/header.html
@@ -1,6 +1,12 @@
 {% load static %}
 
-<header role="banner" class="fr-header">
+<header
+    role="banner"
+    class="
+        fr-header
+        sn-snap-always sn-snap-start
+    "
+>
     <div class="fr-header__body">
         <div class="fr-container">
             <div class="fr-header__body-row">

--- a/unit_tests/carting/test_models.py
+++ b/unit_tests/carting/test_models.py
@@ -17,6 +17,16 @@ def normalize_multiline_string(xml_string):
     ]
 
 
+def test_section_typology_paragraphs():
+    assert SectionTypology.paragraph_likes == {
+        SectionTypology.CHAPTER,
+        SectionTypology.SUBCHAPTER,
+        SectionTypology.PARAGRAPH,
+        SectionTypology.SUBPARAGRAPH,
+        SectionTypology.SUBSUBPARAGRAPH,
+    }
+
+
 # FIXME : tester ingestion de deux ouvrages différents. Mais tester quoi ?
 # FIXME: assert_num_queries
 # FIXME: Tester que si un bpn_id change de place dans le XML, il change de place dans la base ou alors on veut émettre un warning


### PR DESCRIPTION
# Description

This search shows the paragraph-like sections within the bbox (or only chapters when zoomed out enough). When clicking on a paragraph-like details, we switch to a detailed view that shows all sections within that section and does not update with the bbox.
    
- Add a paragraph_likes property for SectionTypology since we often filter by them
- Add some global scroll snap to make it easier to use the UI
- Rename `index` to `search_by_text`
- Introduce Turbo to help with dynamic changes of the content and geojson
- Add some TypeScript typings
- Add possibility to update the bbox in the URL and change the displayed geojson

ref https://github.com/betagouv/SPPNautInterface/issues/130

# TODO
- [x] Dans expanded, les alinéas ne sont plus cliquables
- [x] Dans expanded, les titres ressemblent aux titres dans "pas expanded". (cartes ou liens plus simples ?) (faut que ça invite à cliquer)
- [x] Bouton retour qui remonte d'un niveau, pas qui ferme "expanded"
- [x] Clic sur l'icône Montrer d'un alinéa ne marche pas.
- [x] Throttling bbox update!
- [ ] https://github.com/betagouv/SPPNautInterface/issues/205
- [ ] Bug URL Turbo (mais pas important je crois)
- [x] Ne pas casser la vue text_first
- [ ] Scroll to top après une navigation turbo (autoscroll ne marche pas car overflow: auto)
- [ ] Turbo-frame trop violent pendant la démo quand je cliquais sur une géométrie.

# Idées d'amélioration UX
- [ ] Utiliser une value Stimlus pour figer la liste des résultats dans certains scénarios