### PR TITLE
Fix xml ingester

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Pour faire tourner l'interface en local, il est conseiller d'utiliser :
 Executer,
 
 ```
-./manage.py ingest_ouvrage_xml z99
+./manage.py ingest_ouvrage_xml z99.xml
 ./manage.py import_some_geometry
 ```
 

--- a/carting/management/commands/ingest_ouvrage_xml.py
+++ b/carting/management/commands/ingest_ouvrage_xml.py
@@ -1,27 +1,29 @@
 from xml.etree import ElementTree
+from pathlib import Path
 
 import requests
 from django.conf import settings
 from django.core.management.base import BaseCommand
 
 from carting.models import OuvrageSection
-from spo import generator
+
+# from spo import generator
 
 
 class Command(BaseCommand):
     def add_arguments(self, parser):
         parser.add_argument(
             "ouvrage",
-            help="Ouvrage name, ex = 12, c22, l1",
+            help="Ouvrage xml file, ex = ./12.xml, ./c22.xml, ./l1.xml",
         )
 
     def handle(self, *args, **options):
-        ouvrage_name = options.get("ouvrage")
-        response = generator.get(
-            f"{settings.GENERATOR_SERVICE_HOST}/url-for/{ouvrage_name}/xml/document.xml"
-        )
-        document_xml = requests.get(response.text)
-        content_root = ElementTree.fromstring(document_xml.text)
+        ouvrage_location = options.get("ouvrage")
+
+        document_path = Path(str(ouvrage_location))
+        content_root = ElementTree.parse(document_path)
         # FIXME: Valider bpn_id uniques
-        ingested = OuvrageSection.objects.ingest_xml_subtree(ouvrage_name, content_root)
+        ingested = OuvrageSection.objects.ingest_xml_subtree(
+            document_path.name[:10], content_root
+        )
         self.stdout.write(self.style.SUCCESS(f"✨ {ingested} sections ingérées"))

--- a/carting/management/commands/ingest_ouvrage_xml.py
+++ b/carting/management/commands/ingest_ouvrage_xml.py
@@ -7,8 +7,6 @@ from django.core.management.base import BaseCommand
 
 from carting.models import OuvrageSection
 
-# from spo import generator
-
 
 class Command(BaseCommand):
     def add_arguments(self, parser):

--- a/carting/management/commands/ingest_ouvrage_xml.py
+++ b/carting/management/commands/ingest_ouvrage_xml.py
@@ -13,7 +13,7 @@ class Command(BaseCommand):
         parser.add_argument(
             "ouvrage",
             help="Ouvrage xml file, ex = ./12.xml, ./c22.xml, ./l1.xml",
-            type=Path
+            type=Path,
         )
 
     def handle(self, *args, **options):

--- a/carting/management/commands/ingest_ouvrage_xml.py
+++ b/carting/management/commands/ingest_ouvrage_xml.py
@@ -22,6 +22,6 @@ class Command(BaseCommand):
         content_root = ElementTree.parse(document_path)
         # FIXME: Valider bpn_id uniques
         ingested = OuvrageSection.objects.ingest_xml_subtree(
-            document_path.name[:10], content_root
+            document_path.name, content_root
         )
         self.stdout.write(self.style.SUCCESS(f"✨ {ingested} sections ingérées"))

--- a/carting/management/commands/ingest_ouvrage_xml.py
+++ b/carting/management/commands/ingest_ouvrage_xml.py
@@ -13,15 +13,15 @@ class Command(BaseCommand):
         parser.add_argument(
             "ouvrage",
             help="Ouvrage xml file, ex = ./12.xml, ./c22.xml, ./l1.xml",
+            type=Path
         )
 
     def handle(self, *args, **options):
-        ouvrage_location = options.get("ouvrage")
+        document_path = options.get("ouvrage")
 
-        document_path = Path(str(ouvrage_location))
         content_root = ElementTree.parse(document_path)
         # FIXME: Valider bpn_id uniques
         ingested = OuvrageSection.objects.ingest_xml_subtree(
-            document_path.name, content_root
+            document_path.stem, content_root
         )
         self.stdout.write(self.style.SUCCESS(f"✨ {ingested} sections ingérées"))


### PR DESCRIPTION
Since the removal of SPO in Carting, the XML ouvrage ingester still relies on it.
To remove SPO dependency, we could provide the script with a XML file directly instead. 