### PR TITLE
Remove natsort dependency

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -188,10 +188,6 @@ mypy-extensions==0.4.3 \
     --hash=sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d \
     --hash=sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8
     # via black
-natsort==8.3.1 \
-    --hash=sha256:517595492dde570a4fd6b6a76f644440c1ba51e2338c8a671d7f0475fda8f9fd \
-    --hash=sha256:d583bc9050dd10538de36297c960b93f873f0cd01671a3c50df5bd86dd391dcb
-    # via sppnaut (pyproject.toml)
 packaging==23.0 \
     --hash=sha256:714ac14496c3e68c99c29b00845f7a2b85f3bb6f1078fd9f72fd20f0570002b2 \
     --hash=sha256:b6ad297f8907de0fa2fe1ccbd26fdaf387f5f47c7275fedf8cce89f99446cf97


### PR DESCRIPTION
This was removed in https://github.com/betagouv/SPPNautCarting/pull/280 but dev-requirements.txt was not regenerated.